### PR TITLE
cosmetic correction to qt wallet

### DIFF
--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -45,7 +45,7 @@
          <item>
           <widget class="QValidatedLineEdit" name="addressIn_SM">
            <property name="toolTip">
-            <string>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</string>
+            <string>The address to sign the message with (e.g. RLUvQdRuRc6VXvsBKMwJbXMoyXt3LGtY8F)</string>
            </property>
           </widget>
          </item>
@@ -255,7 +255,7 @@
          <item>
           <widget class="QValidatedLineEdit" name="addressIn_VM">
            <property name="toolTip">
-            <string>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</string>
+            <string>The address the message was signed with (e.g. RLUvQdRuRc6VXvsBKMwJbXMoyXt3LGtY8F)</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
the sample addresses shown were bitccoin addresses starting with a '1' however Riecoin addresses start with R
